### PR TITLE
Added support for @guarded macro and try-catch blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ When an `if` statement is the final statement of a function block or an `if` sta
 ### Loop Blocks
 Whenever a loop block such as `for` or `while` is used they will always return `Void()` which can be accurately inferred by this package.
 
+### Try-Catch Blocks
+When a try-catch block is used it behaves much like an if-then block. The type of the resulting value needs to match both for the try and the catch blocks. In the case that the catch block is omitted, the resulting type of the implicit catch block is Void.
+
 ### Void() != nothing
 The `nothing` keyword can be overwritten to a different value than `Void()`. This means that even though `nothing` is generally considered to be the `Void` singleton that's not necessarily an accurate assumption. This means that even when `nothing` is returned directly annotation is still necessary.
 

--- a/README.md
+++ b/README.md
@@ -15,26 +15,26 @@ example_app = @GtkApplication("com.github.example", 0)
 
 builder = @GtkBuilderAid userdata(example_app::GtkApplication) "resources/main.ui" begin
 
-function click_ok(
+@guarded function click_ok(
     widget, 
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
-function quit_app(
+@guarded function quit_app(
     widget,
     user_info::UserData)
   ccall((:g_application_quit, Gtk.libgtk), Void, (Gtk.GLib.GObject, ), user_info[1])
   return nothing::Void
 end
 
-function close_window(
+@guarded function close_window(
     widget,
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = convert(Gtk.GObject, window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end
@@ -73,7 +73,7 @@ function click_ok(
     widget,
     user_info::UserData)
   println("OK Clicked")
-  return 0::Int
+  return nothing::Void
 end
 ```
 
@@ -88,7 +88,7 @@ function click_ok(
     widget,
     user_info::UserData)
   println("OK Clicked")
-  return 0
+  return nothing::Void
 end
 ```
 
@@ -100,26 +100,26 @@ example_app = @GtkApplication("com.github.example", 0)
 
 builder = @GtkBuilderAid userdatatype(GtkApplication) begin
 
-function click_ok(
+@guarded function click_ok(
     widget,
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
-function quit_app(
+@guarded function quit_app(
     widget,
     user_info::UserData)
   ccall((:g_application_quit, Gtk.libgtk), Void, (Gtk.GLib.GObject, ), user_info[1])
   return nothing::Void
 end
 
-function close_window(
+@guarded function close_window(
     widget,
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = convert(Gtk.GObject, window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end
@@ -152,9 +152,9 @@ When a try-catch block is used it behaves much like an if-then block. The type o
 ### Void() != nothing
 The `nothing` keyword can be overwritten to a different value than `Void()`. This means that even though `nothing` is generally considered to be the `Void` singleton that's not necessarily an accurate assumption. This means that even when `nothing` is returned directly annotation is still necessary.
 
-### `@guarded` macro
+### Macros
 
-The `@guarded` macro is not currently supported within this wrapper, which is a major drawback. Work will be done to rectify this problem sooner rather than later.
+Some macros at the first layer of the block processed by the `@GtkBuilderAid` macro are manually expanded during analysis of that block. The expansion will be kept and used for analysis in the case that the expanded expression is a function definition. Macros that don't result in function definitions will be left to expand as they would have otherwise. This expansion works well enough for simple macros such as the Gtk wrapper library's `@guarded` macro but has the potential to cause complications in more complex macros.
 
 ### Nested Blocks
 

--- a/examples/first.jl
+++ b/examples/first.jl
@@ -7,27 +7,27 @@ example_app = @GtkApplication("com.github.example", 0)
 
 builder = @GtkBuilderAid userdata(example_app::GtkApplication) begin
 
-function click_ok(
+@guarded function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
     evt::Ptr{Gtk.GdkEventButton}, 
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
-function quit_app(
+@guarded function quit_app(
     widget::Ptr{Gtk.GLib.GObject}, 
     user_info::UserData)
   ccall((:g_application_quit, Gtk.libgtk), Void, (Gtk.GLib.GObject, ), user_info[1])
   return nothing::Void
 end
 
-function close_window(
+@guarded function close_window(
     widget::Ptr{Gtk.GLib.GObject}, 
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = Gtk.GLib.GObject(window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end

--- a/src/aidbuild.jl
+++ b/src/aidbuild.jl
@@ -133,6 +133,15 @@ macro GtkBuilderAid(args...)
         line = entry.args[1]
       end
 
+      if entry.head == :macrocall
+        # expand the macro
+        expanded = macroexpand(entry)
+        if expanded.head == :function
+          entry.head = expanded.head
+          entry.args = expanded.args
+        end
+      end
+
       if entry.head == :function
 
         # Modify the first argument to be a Ptr{Gtk.GLib.GObject}

--- a/src/function_inference.jl
+++ b/src/function_inference.jl
@@ -58,17 +58,24 @@ function exprResultType(expr)
       end
       result = :Void
     elseif expr.head == :block
-      if length(expr.args) == 0
+      # Filter out line expressions
+      block_args = []
+      for arg in expr.args
+        if !isa(arg, Expr) || arg.head != :line
+          push!(block_args, arg)
+        end
+      end
+      if length(block_args) == 0
         # An empty block returns void
         result = :Void
       else
         # Blocks evaluate to their final argument
-        result = exprResultType(expr.args[end])
+        result = exprResultType(block_args[end])
       end
     end
     # expr.typ = eval(result)
     if(result == nothing)
-      warn("Did not retrieve a result type!")
+      warn("Did not retrieve a result type: $(expr)")
     end
     return result
   else

--- a/src/function_inference.jl
+++ b/src/function_inference.jl
@@ -26,7 +26,7 @@ function exprResultType(expr)
   if exprtype <: Symbol
     throw(InferenceException("Cannot determine type of Symbols directly"))
   elseif exprtype <: Expr
-    result = Void
+    result = nothing
     if expr.head == :(::)
       # Directly annotated, makes life much easier
       result = expr.args[2]
@@ -50,11 +50,26 @@ function exprResultType(expr)
     elseif expr.head == :while || expr.head == :for
       # while and for always return void
       result = :Void
+    elseif expr.head == :try
+      try_type = exprResultType(expr.args[1])
+      catch_type = exprResultType(expr.args[3])
+      if try_type != catch_type
+        throw(InferenceException("The try-catch blocks provide differing result types"))
+      end
+      result = :Void
     elseif expr.head == :block
-      # Blocks evaluate to their final argument
-      result = exprResultType(expr.args[end])
+      if length(expr.args) == 0
+        # An empty block returns void
+        result = :Void
+      else
+        # Blocks evaluate to their final argument
+        result = exprResultType(expr.args[end])
+      end
     end
     # expr.typ = eval(result)
+    if(result == nothing)
+      warn("Did not retrieve a result type!")
+    end
     return result
   else
     # constants aren't too hard

--- a/test/aidbuild.jl
+++ b/test/aidbuild.jl
@@ -1,4 +1,6 @@
 
+import GtkBuilderAid: InferenceException
+
 function test_macro_throws(error_type, macroexpr)
   expansion = macroexpand(macroexpr)
   if expansion.head != :error
@@ -32,7 +34,7 @@ function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
 function quit_app(
@@ -47,7 +49,7 @@ function close_window(
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = Gtk.GLib.GObject(window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end
@@ -64,7 +66,7 @@ function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
 function quit_app(
@@ -78,7 +80,7 @@ function close_window(
     widget::Ptr{Gtk.GLib.GObject}, 
     window::Ptr{Gtk.GLib.GObject})
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end
@@ -94,7 +96,7 @@ function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
 end
@@ -107,14 +109,14 @@ function close_window(
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = Gtk.GLib.GObject(window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
 end
@@ -132,7 +134,7 @@ function close_window(
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = Gtk.GLib.GObject(window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end
@@ -148,14 +150,14 @@ function close_window(
     widget::Ptr{Gtk.GLib.GObject}, 
     window::Ptr{Gtk.GLib.GObject})
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 function close_window(
     widget::Ptr{Gtk.GLib.GObject}, 
     window::Ptr{Gtk.GLib.GObject})
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 end
@@ -179,19 +181,82 @@ function close_window(
     window_ptr::Ptr{Gtk.GLib.GObject})
   window = Gtk.GLib.GObject(window_ptr)
   destroy(window)
-  return 0
+  return nothing::Void
 end
 
 function click_ok(
     widget,
     user_info::UserData)
   println("OK clicked!")
-  return 0
+  return nothing::Void
 end
 
 end
 
 assumed_builder("resources/nothing.ui")
+
+expanding_builder = @GtkBuilderAid verbose begin
+
+@guarded function close_window(
+    widget,
+    window_ptr::Ptr{Gtk.GLib.GObject})
+  window = Gtk.GLib.GObject(window_ptr)
+  destroy(window)
+  return nothing::Void
+end
+
+@guarded function click_ok(
+    widget,
+    user_info::UserData)
+  println("OK clicked!")
+  return nothing::Void
+end
+
+end
+expanding_builder("resources/nothing.ui")
+
+# Test that issues can arise with expansion
+test_macro_throws(InferenceException, quote
+@GtkBuilderAid verbose begin
+
+@guarded 1 function close_window(
+    widget,
+    window_ptr::Ptr{Gtk.GLib.GObject})
+  window = Gtk.GLib.GObject(window_ptr)
+  destroy(window)
+  return nothing::Void
+end
+
+@guarded 1 function click_ok(
+    widget,
+    user_info::UserData)
+  println("OK clicked!")
+  return nothing::Void
+end
+
+end
+end)
+
+test_macro_throws(InferenceException, quote
+@GtkBuilderAid verbose begin
+
+@guarded function close_window(
+    widget,
+    window_ptr::Ptr{Gtk.GLib.GObject})
+  window = Gtk.GLib.GObject(window_ptr)
+  destroy(window)
+  return 1
+end
+
+@guarded function click_ok(
+    widget,
+    user_info::UserData)
+  println("OK clicked!")
+  return 1
+end
+
+end
+end)
 
 # run(test_app)
 

--- a/test/function_inference.jl
+++ b/test/function_inference.jl
@@ -13,7 +13,6 @@ macro test_macro(args...)
   else
     function_name = args[1]
     return_type = args[2]
-    argument_types = 
     declaration = FunctionDeclaration(function_expr)
     @test declaration.function_name == args[1]
     @test declaration.return_type == args[2]
@@ -30,6 +29,39 @@ end
 @test_throws InferenceException FunctionDeclaration(:(tupe{hello}))
 @test_macro throws begin
   # NOP
+end
+
+@test_macro noBody Void function noBody()
+end
+noBody()
+
+@test_macro tryNoCatch Void function tryNoCatch()
+  try
+    Void()::Void
+  end
+end
+tryNoCatch()
+
+# @test_macro tryWithCatch Int function tryWithCatch()
+#   try
+#     0
+#   catch e
+#     1
+#   end
+# end
+# 
+@test_macro throws function tryNoCatchMismatch()
+  try
+    0
+  end
+end
+
+@test_macro throws function tryCatchMismatch()
+  try
+    0
+  catch
+    0.0
+  end
 end
 
 # Constant explicit return


### PR DESCRIPTION
Support for try-catch blocks is added. Expansion for some macros before the inference process is also added. Particularly, these changes combined enable using the `@guarded` macro from the Julia Gtk wrapper library.
