### PR TITLE
Separate signal connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,3 @@ Functions defined with multiple methods are allowable within Julia but introduce
 
 The first argument must always be a GObject. In cases where a GObject is passed as the user data argument the final argument must also be a GObject. Otherwise the user data argument will be a tuple specified using the macro.
 
-### GTK Version
-
-This package requires using `gtk_builder_add_callback_symbols` at the moment which was introduced in GTK version 3.10 which was released in late 2013. Unfortunately, this means distributions released before 2014 may run into difficulties utilizing this package due to binary dependencies. There are plans to rework the library to utilize `gtk_builder_connect_signals_full` instead which has been available since GTK version 2.12 and gives greater control besides.
-

--- a/src/GtkBuilderAid.jl
+++ b/src/GtkBuilderAid.jl
@@ -7,6 +7,7 @@ using Gtk
 export @GtkBuilderAid
 
 include("function_inference.jl")
+include("connect_signals.jl")
 include("aidbuild.jl")
 
 end # module

--- a/src/connect_signals.jl
+++ b/src/connect_signals.jl
@@ -1,0 +1,81 @@
+
+immutable FunctionInfo
+  func::Function
+  return_type::Type
+  argument_types::Array{Type}
+end
+
+type SignalConnectionData
+  handlers::Dict{AbstractString, FunctionInfo}
+  data
+end
+
+# A cfunction to configure connections
+function connectSignalsCFunction(
+    builder, 
+    object_ptr, 
+    signal_name_ptr, 
+    handler_name_ptr, 
+    connect_object_ptr, 
+    flags, 
+    userdata_ptr)
+
+  userdata = unsafe_pointer_to_objref(userdata_ptr)
+
+  handler_name = bytestring(handler_name_ptr)
+  handler = userdata.handlers[handler_name]
+  
+  if connect_object_ptr == C_NULL
+    # Use the provided 
+    object = Gtk.GLib.GObject(object_ptr)
+    signal_name = bytestring(signal_name_ptr)
+
+    signal_connect(
+        handler.func, 
+        object, 
+        signal_name, 
+        handler.return_type, 
+        (handler.argument_types[2:end - 1]...), 
+        false, 
+        userdata.data)
+  else
+    # Connect the objects directly
+    handler.argument_types[1] = Ptr{Gtk.GLib.GObject}
+    handler.argument_types[end] = Ptr{Gtk.GLib.GObject}
+    ccall(
+        (:g_signal_connect_object, Gtk.libgtk),
+        Culong,
+        (Ptr{Gtk.GLib.GObject}, Ptr{UInt8}, Ptr{Void}, Ptr{Gtk.GLib.GObject}, Gtk.GEnum),
+        object_ptr,
+        signal_name_ptr,
+        cfunction(handler.func, handler.return_type, (handler.argument_types...)),
+        connect_object_ptr,
+        flags)
+  end
+
+  return nothing
+end
+
+function connectSignals(
+    built::GtkBuilderLeaf, 
+    handlers::Dict{ByteString, FunctionInfo}, 
+    userdata)
+  connector = cfunction(
+      connectSignalsCFunction, 
+      Void, 
+      (
+          Ptr{Gtk.GLib.GObject}, 
+          Ptr{Gtk.GLib.GObject},
+          Ptr{UInt8},
+          Ptr{UInt8},
+          Ptr{Gtk.GLib.GObject},
+          Int,
+          Ptr{Void}))
+  ccall(
+      (:gtk_builder_connect_signals_full, Gtk.libgtk),
+      Void,
+      (Ptr{Gtk.GLib.GObject}, Ptr{Void}, Ptr{Void}), 
+      built, 
+      connector,
+      pointer_from_objref(SignalConnectionData(handlers, userdata)))
+end

--- a/test/aidbuild.jl
+++ b/test/aidbuild.jl
@@ -60,7 +60,7 @@ long_builder("resources/nothing.ui", (test_app, ))
 
 # Show the expanded macro
 # Mostly check that this succeeds
-builder = @GtkBuilderAid verbose userdata(test_app::GtkApplication) "resources/nothing.ui" begin
+builder = @GtkBuilderAid userdata(test_app::GtkApplication) "resources/nothing.ui" begin
 
 function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
@@ -174,7 +174,7 @@ end
 
 signal_connect(activateApp, test_app, :activate, Void, (), false, (test_app, builder))
 
-assumed_builder = @GtkBuilderAid verbose begin
+assumed_builder = @GtkBuilderAid begin
 
 function close_window(
     widget,
@@ -195,7 +195,7 @@ end
 
 assumed_builder("resources/nothing.ui")
 
-expanding_builder = @GtkBuilderAid verbose begin
+expanding_builder = @GtkBuilderAid begin
 
 @guarded function close_window(
     widget,
@@ -217,7 +217,7 @@ expanding_builder("resources/nothing.ui")
 
 # Test that issues can arise with expansion
 test_macro_throws(InferenceException, quote
-@GtkBuilderAid verbose begin
+@GtkBuilderAid begin
 
 @guarded 1 function close_window(
     widget,
@@ -238,7 +238,7 @@ end
 end)
 
 test_macro_throws(InferenceException, quote
-@GtkBuilderAid verbose begin
+@GtkBuilderAid begin
 
 @guarded function close_window(
     widget,

--- a/test/aidbuild.jl
+++ b/test/aidbuild.jl
@@ -5,7 +5,7 @@ function test_macro_throws(error_type, macroexpr)
   expansion = macroexpand(macroexpr)
   if expansion.head != :error
     warn("Expansion did not throw error")
-    dump(expansion)
+    println(expansion)
     @test false
   end
   if !isa(expansion.args[1], error_type)
@@ -18,11 +18,25 @@ function test_macro_throws(error_type, macroexpr)
 end
 
 test_macro_throws(TypeError, quote 
-@GtkBuilderAid hello
+@GtkBuilderAid helloSymbol
+end)
+
+test_macro_throws(ArgumentError, quote
+@GtkBuilderAid helloExpr()
 end)
 
 test_macro_throws(ArgumentError, quote 
 @GtkBuilderAid 
+end)
+
+test_macro_throws(ErrorException, quote
+@GtkBuilderAid symbolDirective begin
+end
+end)
+
+test_macro_throws(ErrorException, quote
+@GtkBuilderAid badexpr::Directive begin
+end
 end)
 
 test_app = @GtkApplication("com.github.test_gtkbuilderaid", 0)
@@ -92,6 +106,14 @@ builder("$(Pkg.dir("GtkBuilderAid"))/test/resources/nothing.ui")
 # check again but with an explicit name for the builder function
 @GtkBuilderAid function_name(build_nothing) userdata(test_app::GtkApplication) "resources/nothing.ui" begin
 
+function close_window(
+    widget::Ptr{Gtk.GLib.GObject}, 
+    window_ptr::Ptr{Gtk.GLib.GObject})
+  window = Gtk.GLib.GObject(window_ptr)
+  destroy(window)
+  return nothing::Void
+end
+
 function click_ok(
     widget::Ptr{Gtk.GLib.GObject}, 
     user_info::UserData)
@@ -100,6 +122,7 @@ function click_ok(
 end
 
 end
+build_nothing()
 
 # Test non-string file arguments
 base_method_builder = @GtkBuilderAid begin
@@ -215,7 +238,11 @@ end
 end
 expanding_builder("resources/nothing.ui")
 
+@test_throws ErrorException expanding_builder("resources/nonexistant.ui")
+
 # Test that issues can arise with expansion
+
+# Test that mismatching return values with the use of guarded causes errors
 test_macro_throws(InferenceException, quote
 @GtkBuilderAid begin
 
@@ -237,6 +264,7 @@ end
 end
 end)
 
+# Test that mismatching return values with the use of guarded causes errors
 test_macro_throws(InferenceException, quote
 @GtkBuilderAid begin
 


### PR DESCRIPTION
- Allows signal connection without using the macro
- Improves detection of explicit return types
- Expands code coverage.
