### PR TITLE
Allow nightly failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ os:
 julia:
   - 0.4
   - release
+  - nightly
+matrix:
+  allow_failures:
+    - nightly
 notifications:
   email: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ julia:
   - nightly
 matrix:
   allow_failures:
-    - nightly
+    - julia: nightly
 notifications:
   email: false
 addons:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 This package's functionality is very narrowly to enable creating Gtk GUIs using [Glade](https://glade.gnome.org/) and [Julia](http://julialang.org/) more simply than can be accomplished using only the [Julia interface to Gtk](https://github.com/JuliaLang/Gtk.jl). The main concept is to use the signal connection features of the GtkBuilder object as simply in Julia as they can be from C.
 
+## Installation
+
+This package can be installed by use of Julia's in-built package manager as the `GtkBuilderAid` package. As a result `Pkg.add` is usually sufficient to install this package:
+
+```julia
+Pkg.add("GtkBuilderAid")
+```
+
 ## Example
 
 A simple example that matches up with the shown GUI is displayed below.


### PR DESCRIPTION
As suggested in a note I've restored julia nightly as an allowable failure.Right now the build failure is caused by the Gtk package failing to precompile in julia 0.5 right now. Either the Gtk package or julia 0.5 release version will resolve this.

In general I shouldn't have nightly as a required success as it's a moving target that can fail for many reasons beyond the control of this package.
