### PR TITLE
v0.5 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ dist: trusty
 os:
   - linux
 julia:
-  - 0.4
-  - release
+  - 0.5
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 Cairo 0.2.24
 Gtk 0.8.4
 Compat 0.8.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.5
 Cairo 0.2.24
 Gtk 0.8.4
-Compat 0.8.0

--- a/src/GtkBuilderAid.jl
+++ b/src/GtkBuilderAid.jl
@@ -3,7 +3,6 @@ __precompile__()
 module GtkBuilderAid
 using Gtk
 using Cairo
-using Compat
 
 export @GtkBuilderAid
 

--- a/src/aidbuild.jl
+++ b/src/aidbuild.jl
@@ -135,8 +135,8 @@ macro GtkBuilderAid(args...)
     #   ccall(userdata.func, T, (O, X1 ... XN, P), GObject(object), x_1 ... x_n, GObject(userdata.data))
     # Inserts additional arguments
     for i in 1:passthrough - 2
-      var = symbol("x_", i)
-      typ = symbol("X", i)
+      var = Symbol("x_", i)
+      typ = Symbol("X", i)
       insert!(new_passthrough_decl.args, 3, :($var::$typ))
       insert!(new_passthrough_expr.args, 5, var)
       push!(new_passthrough_decl.args[1].args, typ)
@@ -160,7 +160,6 @@ macro GtkBuilderAid(args...)
   block = quote
     $(esc(user_block))
     $passthrough_expr
-    handlers
 
     handlers = Dict{Compat.String, Function}()
     for func in $(esc(funcdata))

--- a/src/aidbuild.jl
+++ b/src/aidbuild.jl
@@ -161,7 +161,7 @@ macro GtkBuilderAid(args...)
     $(esc(user_block))
     $passthrough_expr
 
-    handlers = Dict{Compat.String, Function}()
+    handlers = Dict{String, Function}()
     for func in $(esc(funcdata))
       handlers[string(func[2])] = func[1]
     end

--- a/src/connect_signals.jl
+++ b/src/connect_signals.jl
@@ -99,7 +99,7 @@ end
 
 """
 ```julia
-query_signal(obj::GObject, signal_name::Compat.String)::SignalInfo
+query_signal(obj::GObject, signal_name::String)::SignalInfo
 ```
 For internal use.
 
@@ -108,7 +108,7 @@ Looks up details about a particular signal on an object and provides it as
 * `obj` - The GObject to get the details of the signal for.
 * `signal_name` - The name of the signal to get details for
 """
-function query_signal(obj::GObject, signal_name::Compat.String)
+function query_signal(obj::GObject, signal_name::String)
   obj_class = Gtk.GLib.G_OBJECT_CLASS_TYPE(obj)
   signal_id = ccall(
     (:g_signal_lookup, Gtk.GLib.libgobject),
@@ -139,7 +139,7 @@ For internal use.
 
 """
 type SignalConnectionData
-  handlers::Dict{Compat.String, Function}
+  handlers::Dict{String, Function}
   data
   warn_pipe::IO
   passthrough::Function
@@ -234,7 +234,7 @@ end
 ```julia
 connect_signals(
     built::GtkBuilderLeaf,
-    handlers::Dict{Compat.String, Function}, 
+    handlers::Dict{String, Function}, 
     userdata,
     passthrough::Function;
     wpipe=Base.STDERR)
@@ -250,7 +250,7 @@ functionality.
 """
 function connect_signals(
     built::GtkBuilderLeaf, 
-    handlers::Dict{Compat.String, Function}, 
+    handlers::Dict{String, Function}, 
     userdata,
     passthrough::Function;
     wpipe=Base.STDERR)

--- a/test/aidbuild.jl
+++ b/test/aidbuild.jl
@@ -67,7 +67,6 @@ type InternalData
   counter::Int
 end
 
-println("BEFORE")
 @GtkBuilderAid function_name(long_builder) begin
 
 @guarded function click_ok(


### PR DESCRIPTION
There aren't too many fixes necessary to jump to julia v0.5. Since nobody seems too interested in this package anyway, I feel it's pretty safe to drop v0.4 support. I'll be tagging the next version as a minor version though, if for some reason v0.4 backporting ends up being necessary.
